### PR TITLE
VSCode for Engine-Source on Windows: Split up build process, etc.

### DIFF
--- a/VSCode_Engine-Source_Windows/.vscode/launch.json
+++ b/VSCode_Engine-Source_Windows/.vscode/launch.json
@@ -20,7 +20,7 @@
             "type": "cppvsdbg",
             "request": "launch",
             "program": "${workspaceFolder}/bin/vegastrike-engine.exe",
-            "args": [ "-d${workspaceFolder}/../privateer_wcu/" ],
+            "args": [ "-d${workspaceFolder}/../privateer_wcu/", "--debug=3" ],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",
             "environment": [],

--- a/VSCode_Engine-Source_Windows/.vscode/settings.json
+++ b/VSCode_Engine-Source_Windows/.vscode/settings.json
@@ -96,5 +96,5 @@
         }
     },
     "cmake.saveBeforeBuild": true,
-    "cmake.buildTask": true
+    "cmake.buildTask": false
 }

--- a/VSCode_Engine-Source_Windows/.vscode/tasks.json
+++ b/VSCode_Engine-Source_Windows/.vscode/tasks.json
@@ -4,19 +4,52 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "build",
+            "label": "cmake-build",
+            "type": "cmake",
+            "command": "build",
+            "group": "build",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "shared",
+                "showReuseMessage": false,
+                "clear": false
+            },
+            "problemMatcher": "$msCompile",
+            "runOptions": {
+                "instanceLimit": 1
+            }
+        },
+        {
+            "label": "post-build-copy-binaries",
             "type": "shell",
-            "command": "script/build.ps1",
+            "command": "xcopy /y build\\${command:cmake.buildType}\\*.* .\\bin\\",
+            "group": "build",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "shared",
+                "showReuseMessage": false,
+                "clear": false
+            },
+            "problemMatcher": "$msCompile",
+            "runOptions": {
+                "instanceLimit": 1
+            }
+        },
+        {
+            "label": "build-complete",
+            "dependsOn": [
+                "cmake-build",
+                "post-build-copy-binaries"
+            ],
+            "dependsOrder": "sequence",
             "group": {
                 "kind": "build",
                 "isDefault": true
-            },
-            "presentation": {
-                // Reveal the output only if unrecognized errors occur.
-                "reveal": "always"
-            },
-            // Use the standard MS compiler pattern to detect errors, warnings and infos
-            "problemMatcher": "$msCompile"
+            }
         }
     ]
 }


### PR DESCRIPTION
Now you can build Vega-Strike-Engine-Source in RelWithDebInfo configuration, as well as in Release configuration, and the VSCode stuff will still work correctly.